### PR TITLE
Copy model directories instead of entire AtChem2 root directories

### DIFF
--- a/AtChemTools/build_and_run.py
+++ b/AtChemTools/build_and_run.py
@@ -1,8 +1,6 @@
 #imports
 import os
 import pandas as pd
-from datetime import datetime
-import tempfile
 import numpy as np
 from .species_from_mechanism import return_all_species
 import warnings
@@ -52,7 +50,7 @@ def dataframe_to_config_files(in_df : pd.DataFrame, dirpath : str,
         with open(dirpath+os.sep+col,"w") as file:
             file.writelines(lines)
         
-def write_config(atchem2_path : str, initial_concs : pd.Series = pd.Series(), 
+def write_config(model_path : str, initial_concs : pd.Series = pd.Series(), 
                  spec_constrain : pd.DataFrame = pd.DataFrame(), 
                  spec_constant : pd.Series = pd.Series(), 
                  env_constrain : pd.DataFrame = pd.DataFrame(), 
@@ -72,30 +70,30 @@ def write_config(atchem2_path : str, initial_concs : pd.Series = pd.Series(),
     
     #initialConcentrations.config
     series_to_config_file(initial_concs.dropna(), 
-                        f"{atchem2_path}/model/configuration/initialConcentrations.config")
+                        f"{model_path}/configuration/initialConcentrations.config")
         
     #speciesConstrained.config
     list_to_config_file(list(spec_constrain.columns), 
-                        f"{atchem2_path}/model/configuration/speciesConstrained.config")
+                        f"{model_path}/configuration/speciesConstrained.config")
     #species constraints
-    dataframe_to_config_files(spec_constrain,f"{atchem2_path}/model/constraints/species/")
+    dataframe_to_config_files(spec_constrain,f"{model_path}/constraints/species/")
         
     #photolysisConstrained.config
     list_to_config_file(list(photo_constrain.columns), 
-                        f"{atchem2_path}/model/configuration/photolysisConstrained.config")
+                        f"{model_path}/configuration/photolysisConstrained.config")
     #photolysis constraints
-    dataframe_to_config_files(photo_constrain,f"{atchem2_path}/model/constraints/photolysis/")
+    dataframe_to_config_files(photo_constrain,f"{model_path}/constraints/photolysis/")
 
     #speciesConstant.config
     series_to_config_file(spec_constant.dropna(), 
-                          f"{atchem2_path}/model/configuration/speciesConstant.config")
+                          f"{model_path}/configuration/speciesConstant.config")
     
     #photolysisConstant.config 
     #make lines for config file which has to be in the format "1 1E-4 J1" etc.
     pconst_lines = [f"{k.strip('J')} {v} {k}" for k,v in photo_constant.items()]
     
     list_to_config_file(pconst_lines,
-                        f"{atchem2_path}/model/configuration/photolysisConstant.config")
+                        f"{model_path}/configuration/photolysisConstant.config")
     
     
     #environmentVariables.config
@@ -128,27 +126,27 @@ def write_config(atchem2_path : str, initial_concs : pd.Series = pd.Series(),
     for i,k in enumerate([x for x in env_copy.index if x not in default_env.index]):
         env_var_lines += f"\n{11+i} {k} {env_copy[k]}"
     
-    with open(f"{atchem2_path}/model/configuration/environmentVariables.config","w") as file:
+    with open(f"{model_path}/configuration/environmentVariables.config","w") as file:
         file.write(env_var_lines)
 
     #environment constraints
     for col in env_constrain.columns:
         if env_copy[col] == "CONSTRAINED":
             if col != "JFAC":
-                env_path = f"{atchem2_path}/model/constraints/environment/{col}"
+                env_path = f"{model_path}/constraints/environment/{col}"
             else:
-                env_path = f"{atchem2_path}/model/constraints/photolysis/{col}"
+                env_path = f"{model_path}/constraints/photolysis/{col}"
             series_to_config_file(env_constrain[col].dropna(), env_path)
         else:
             raise Exception(f"Constraint provided for {col}, but value is set as {env_copy[col]} not 'CONSTRAINED'")   
         
     #outputSpecies.config and outputRates.config
     list_to_config_file(spec_output,
-                        f"{atchem2_path}/model/configuration/outputSpecies.config")
+                        f"{model_path}/configuration/outputSpecies.config")
     list_to_config_file(rate_output,
-                        f"{atchem2_path}/model/configuration/outputRates.config")    
+                        f"{model_path}/configuration/outputRates.config")    
     
-def write_model_params(atchem2_path : str, nsteps : int, model_tstep : int, 
+def write_model_params(model_path : str, nsteps : int, model_tstep : int, 
                        tstart : int, day : int, month : int, year : int, 
                        lat : float, lon : float):
     """Write the provided input data to the model parameters file of the 
@@ -168,7 +166,7 @@ def write_model_params(atchem2_path : str, nsteps : int, model_tstep : int,
     {year:04d}			year
     {model_tstep}			reaction rates output step size (seconds)"""
 
-    with open(atchem2_path+"/model/configuration/model.parameters","w") as file:
+    with open(model_path+"/configuration/model.parameters","w") as file:
         file.write(model_params_lines)
     
 
@@ -179,13 +177,28 @@ def build_model(atchem2_path : str, mechanism_path : str):
     os.system(f"{atchem2_path}/build/build_atchem2.sh {mechanism_path}")
     os.chdir(script_dir)
 
-def run_model(atchem2_path : str):
+def run_model(atchem2_path : str, model_path : str = ""):
     """Runs the specified (pre-built) AtChem2 model"""
     script_dir = os.getcwd()
     os.chdir(atchem2_path)
-    os.system(f"{atchem2_path}/atchem2")
+    if model_path:
+        os.system(f"{atchem2_path}/atchem2 --model={model_path}")
+    else:
+        os.system(f"{atchem2_path}/atchem2")
     os.chdir(script_dir)
+
+def find_unique_dirname(atchem2_path : str):
+    """Looks for existing model sub-direcotries in the AtChem2 directory and 
+    creates a unique model sub-directory name. This avoids over-writing existing 
+    model sub-directories when running a new simulation."""
+    base_dirname = "model"
+    curr_dirs = os.listdir(atchem2_path)
     
+    i = 1
+    while f"{base_dirname}{i}" in curr_dirs:
+        i += 1
+            
+    return f"{base_dirname}{i}"
                         
 def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str, 
                                 mech_path : str, day : int, 
@@ -195,7 +208,8 @@ def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str,
                                 spec_constant : pd.Series, env_constrain : pd.DataFrame, 
                                 photo_constant : pd.Series, photo_constrain : pd.DataFrame, 
                                 env_vals : pd.Series, spec_output : list, 
-                                rate_output : list, lat : float, lon : float):
+                                rate_output : list, lat : float, lon : float,
+                                keep_rundirs : bool):
     """Called by the 'write_build_run' function to configure, build and run
     a specified AtChem2 model including instantaneous increases in 
     concentrations of certain species. """
@@ -223,15 +237,16 @@ def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str,
     all_specs = return_all_species(mech_path)
     
     for i,inj_time in enumerate(ordered_times):
-        #copy atchem2 directory
-        new_atchem_path = f"{tempfile.gettempdir()}/AtChem2_{year:04d}-{month:02d}-{day:02d}_{i}_{datetime.now()}".replace(' ','_')
-        os.system(f"cp -r {atchem2_path} {new_atchem_path}")
+        #copy atchem2 model directory 
+        new_model_dir = find_unique_dirname(atchem2_path)
+        new_model_path = f"{atchem2_path}/{new_model_dir}"
+        os.system(f"cp -r {atchem2_path}/model {new_model_path}")
         #copy the mechanism to the AtChem directory
-        new_mech_path = f"{new_atchem_path}/model/{mech_path.split('/')[-1]}"
+        new_mech_path = f"{new_model_path}/{mech_path.split('/')[-1]}"
         os.system(f"cp {mech_path} {new_mech_path}")
         
         #write config files using data passed
-        write_config(new_atchem_path, initial_concs=initial_concs, 
+        write_config(new_model_path, initial_concs=initial_concs, 
                      spec_constrain=spec_constrain, spec_constant=spec_constant,
                      env_constrain=env_constrain, env_vals=env_vals, 
                      photo_constant = photo_constant, photo_constrain = photo_constrain,
@@ -273,7 +288,7 @@ def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str,
             
             init_lines = [f"{k} {v}\n" for k,v in new_start_concs.to_dict().items()]
             
-            with open(new_atchem_path+"/model/configuration/initialConcentrations.config",
+            with open(new_model_path+"/configuration/initialConcentrations.config",
                       "w") as file:
                 file.writelines(init_lines)
         
@@ -283,25 +298,25 @@ def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str,
         model_length=(next_injtime+step_size) - inj_time
         nsteps=int(model_length/step_size)
                
-        write_model_params(new_atchem_path, nsteps, step_size, inj_time, day, 
+        write_model_params(new_model_path, nsteps, step_size, inj_time, day, 
                            month, year, lat=lat, lon=lon)
         
         #build and run the model
-        build_model(new_atchem_path, new_mech_path)
-        run_model(new_atchem_path)
+        build_model(atchem2_path, new_mech_path)
+        run_model(atchem2_path, new_model_dir)
         
         #read the model output and append it to the stitched df
-        output = pd.read_csv(f"{new_atchem_path}/model/output/speciesConcentrations.output", 
+        output = pd.read_csv(f"{new_model_path}/output/speciesConcentrations.output", 
                              index_col=0, sep='\s+')
-        loss_output = pd.read_csv(f"{new_atchem_path}/model/output/lossRates.output", 
+        loss_output = pd.read_csv(f"{new_model_path}/output/lossRates.output", 
                                   sep='\s+',
                                   keep_default_na=False)
-        prod_output = pd.read_csv(f"{new_atchem_path}/model/output/productionRates.output", 
+        prod_output = pd.read_csv(f"{new_model_path}/output/productionRates.output", 
                                   sep='\s+',
                                   keep_default_na=False)
-        env_output = pd.read_csv(f"{new_atchem_path}/model/output/environmentVariables.output", 
+        env_output = pd.read_csv(f"{new_model_path}/output/environmentVariables.output", 
                                  index_col=0, sep='\s+')
-        photo_output = pd.read_csv(f"{new_atchem_path}/model/output/photolysisRates.output", 
+        photo_output = pd.read_csv(f"{new_model_path}/output/photolysisRates.output", 
                                  index_col=0, sep='\s+')
 
         #trim off the values that are accounted for by subsequent iterations
@@ -318,8 +333,9 @@ def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str,
         stitched_env = pd.concat([stitched_env, env_output])
         stitched_photo = pd.concat([stitched_photo, photo_output])
     
-        #remove temporary AtChem2 copy
-        os.system(f"rm -r {new_atchem_path}")
+        #remove model directory (unless requested to keep)
+        if not keep_rundirs:
+            os.system(f"rm -r {new_model_path}")
         
     #select only the output speices
     stitched_output = stitched_output[spec_output]
@@ -337,7 +353,8 @@ def _write_build_run_nox_constraint(nox_series : pd.Series, atchem2_path : str,
                                     spec_constant : pd.Series, env_constrain : pd.DataFrame, 
                                     photo_constant : pd.Series, photo_constrain : pd.DataFrame, 
                                     env_vals : pd.Series, spec_output : list, 
-                                    rate_output : list, lat : float, lon : float):
+                                    rate_output : list, lat : float, lon : float,
+                                    keep_rundirs : bool):
     """Called by the 'write_build_run' function to configures, build and run
     a specified AtChem2 model including a constraint on total NOx, while NO 
     and NO2 are allowed to vary freely.
@@ -373,15 +390,17 @@ BUILDING OF MANY INDIVIDUAL MODELS.""")
     for istep in range(nsteps):
         step_time = t_start + (istep*step_size)
         
-        #copy atchem2 directory
-        new_atchem_path = f"{tempfile.gettempdir()}/AtChem2_{year:04d}-{month:02d}-{day:02d}_{istep}_{datetime.now()}".replace(' ','_')
-        os.system(f"cp -r {atchem2_path} {new_atchem_path}")
+        #copy atchem2 model directory 
+        new_model_dir = find_unique_dirname(atchem2_path)
+        new_model_path = f"{atchem2_path}/{new_model_dir}"
+        os.system(f"cp -r {atchem2_path}/model {new_model_path}")
+
         #copy the mechanism to the AtChem directory
-        new_mech_path = f"{new_atchem_path}/model/{mech_path.split('/')[-1]}"
+        new_mech_path = f"{new_model_path}/{mech_path.split('/')[-1]}"
         os.system(f"cp {mech_path} {new_mech_path}")
         
         #write config files using data passed
-        write_config(new_atchem_path, initial_concs=initial_concs, 
+        write_config(new_model_path, initial_concs=initial_concs, 
                      spec_constrain=spec_constrain, spec_constant=spec_constant,
                      env_constrain=env_constrain, env_vals=env_vals, 
                      photo_constant = photo_constant, photo_constrain = photo_constrain,
@@ -410,7 +429,7 @@ BUILDING OF MANY INDIVIDUAL MODELS.""")
             
             init_lines = [f"{k} {v}\n" for k,v in new_start_concs.to_dict().items()]
             
-            with open(new_atchem_path+"/model/configuration/initialConcentrations.config",
+            with open(new_model_path+"/configuration/initialConcentrations.config",
                       "w") as file:
                 file.writelines(init_lines)
         else: #just check that we have some NOx in the model if this is the first step
@@ -419,7 +438,7 @@ BUILDING OF MANY INDIVIDUAL MODELS.""")
                 #given NOx value 50:50 between NO and NO2
                 half_val = nox_series_interp[step_time]/2
                 
-                with open(new_atchem_path+"/model/configuration/initialConcentrations.config",
+                with open(new_model_path+"/configuration/initialConcentrations.config",
                           "a") as file:
                     file.write(f"NO2 {half_val}\nNO {half_val}")
             
@@ -427,25 +446,25 @@ BUILDING OF MANY INDIVIDUAL MODELS.""")
         #rewrite model parameters file to only run for the length of the 
         #injection of interest
                
-        write_model_params(new_atchem_path, 1, step_size, step_time, day, 
+        write_model_params(new_model_path, 1, step_size, step_time, day, 
                            month, year, lat=lat, lon=lon)
         
         #build and run the model
-        build_model(new_atchem_path, new_mech_path)
-        run_model(new_atchem_path)
+        build_model(atchem2_path, new_mech_path)
+        run_model(atchem2_path, new_model_dir)
         
         #read the model output and append it to the stitched df
-        output = pd.read_csv(f"{new_atchem_path}/model/output/speciesConcentrations.output", 
+        output = pd.read_csv(f"{new_model_path}/output/speciesConcentrations.output", 
                              index_col=0, sep='\s+')
-        loss_output = pd.read_csv(f"{new_atchem_path}/model/output/lossRates.output", 
+        loss_output = pd.read_csv(f"{new_model_path}/output/lossRates.output", 
                                   sep='\s+',
                                   keep_default_na=False)
-        prod_output = pd.read_csv(f"{new_atchem_path}/model/output/productionRates.output", 
+        prod_output = pd.read_csv(f"{new_model_path}/output/productionRates.output", 
                                   sep='\s+',
                                   keep_default_na=False)
-        env_output = pd.read_csv(f"{new_atchem_path}/model/output/environmentVariables.output", 
+        env_output = pd.read_csv(f"{new_model_path}/output/environmentVariables.output", 
                                  index_col=0, sep='\s+')
-        photo_output = pd.read_csv(f"{new_atchem_path}/model/output/photolysisRates.output", 
+        photo_output = pd.read_csv(f"{new_model_path}/output/photolysisRates.output", 
                                  index_col=0, sep='\s+')
 
         #trim off the first value (if this isn't the first step)
@@ -460,8 +479,9 @@ BUILDING OF MANY INDIVIDUAL MODELS.""")
         stitched_env = pd.concat([stitched_env, env_output])
         stitched_photo = pd.concat([stitched_photo, photo_output])
 
-        #remove temporary AtChem2 copy
-        os.system(f"rm -r {new_atchem_path}")
+        #remove model directory (unless requested to keep)
+        if not keep_rundirs:
+            os.system(f"rm -r {new_model_path}")
         
     #select only the output speices
     stitched_output = stitched_output[spec_output]
@@ -487,7 +507,7 @@ def write_build_run(atchem2_path : str, mech_path : str, day : int, month : int,
                                                               "RH", "H2O", "DEC", 
                                                               "BLHEIGHT", "DILUTE", 
                                                               "JFAC", "ROOF", "ASA"]),
-                    spec_output : list = [], rate_output : list = [], 
+                    spec_output : list = [], rate_output : list = [], keep_rundirs : bool = False,
                     injection_df : pd.DataFrame = pd.DataFrame, nox_series : pd.Series = pd.Series):
     """Configures, builds and runs a specified AtChem2 model. 
     
@@ -535,7 +555,7 @@ def write_build_run(atchem2_path : str, mech_path : str, day : int, month : int,
                                            spec_output = spec_output,
                                            rate_output = rate_output,
                                            lat = lat,
-                                           lon = lon)
+                                           lon = lon, keep_rundirs = keep_rundirs)
     elif not nox_series.empty:
         return _write_build_run_nox_constraint(nox_series = nox_series, 
                                                atchem2_path = atchem2_path, 
@@ -556,18 +576,20 @@ def write_build_run(atchem2_path : str, mech_path : str, day : int, month : int,
                                                spec_output = spec_output,
                                                rate_output = rate_output,
                                                lat = lat,
-                                               lon = lon)
+                                               lon = lon, keep_rundirs = keep_rundirs)
     else:
     
-        #copy atchem2 directory
-        new_atchem_path = f"{tempfile.gettempdir()}/AtChem2_{year:04d}-{month:02d}-{day:02d}_{datetime.now()}".replace(' ','_')
-        os.system(f"cp -r {atchem2_path} {new_atchem_path}")
+        #copy atchem2 model directory 
+        new_model_dir = find_unique_dirname(atchem2_path)
+        new_model_path = f"{atchem2_path}/{new_model_dir}"
+        os.system(f"cp -r {atchem2_path}/model {new_model_path}")
+
         #copy the mechanism to the AtChem directory
-        new_mech_path = f"{new_atchem_path}/model/{mech_path.split('/')[-1]}"
+        new_mech_path = f"{new_model_path}/{mech_path.split('/')[-1]}"
         os.system(f"cp {mech_path} {new_mech_path}")
         
         #write config files using data passed
-        write_config(new_atchem_path, initial_concs=initial_concs, 
+        write_config(new_model_path, initial_concs=initial_concs, 
                      spec_constrain=spec_constrain, spec_constant=spec_constant,
                      env_constrain=env_constrain, env_vals=env_vals, 
                      photo_constant = photo_constant, photo_constrain = photo_constrain,
@@ -578,34 +600,33 @@ def write_build_run(atchem2_path : str, mech_path : str, day : int, month : int,
         model_length=t_end-t_start
         nsteps=int(model_length/step_size)
     
-        write_model_params(new_atchem_path, nsteps, step_size, t_start, day, 
+        write_model_params(new_model_path, nsteps, step_size, t_start, day, 
                            month, year, lat=lat, lon=lon)
         
         #build and run the model
-        build_model(new_atchem_path, new_mech_path)
-        run_model(new_atchem_path)
+        build_model(atchem2_path, new_mech_path)
+        run_model(atchem2_path, new_model_dir)
         
         #read the model output 
-        output = pd.read_csv(f"{new_atchem_path}/model/output/speciesConcentrations.output", 
+        output = pd.read_csv(f"{new_model_path}/output/speciesConcentrations.output", 
                              index_col=0, sep='\s+')
         
-        
-        loss_output = pd.read_csv(f"{new_atchem_path}/model/output/lossRates.output", 
+        loss_output = pd.read_csv(f"{new_model_path}/output/lossRates.output", 
                                   sep='\s+',
                                   keep_default_na=False)
-        prod_output = pd.read_csv(f"{new_atchem_path}/model/output/productionRates.output", 
+        prod_output = pd.read_csv(f"{new_model_path}/output/productionRates.output", 
                                   sep='\s+',
                                   keep_default_na=False)
         
-    
-        env_output = pd.read_csv(f"{new_atchem_path}/model/output/environmentVariables.output", 
+        env_output = pd.read_csv(f"{new_model_path}/output/environmentVariables.output", 
                                  index_col=0, sep='\s+')
         
-        photo_output = pd.read_csv(f"{new_atchem_path}/model/output/photolysisRates.output", 
+        photo_output = pd.read_csv(f"{new_model_path}/output/photolysisRates.output", 
                                  index_col=0, sep='\s+')
         
-        #remove temporary AtChem2 copy
-        os.system(f"rm -r {new_atchem_path}")
+        #remove model directory (unless requested to keep)
+        if not keep_rundirs:
+            os.system(f"rm -r {new_model_path}")
         
         return (output, loss_output, prod_output, env_output, photo_output)
 

--- a/AtChemTools/build_and_run.py
+++ b/AtChemTools/build_and_run.py
@@ -170,11 +170,11 @@ def write_model_params(model_path : str, nsteps : int, model_tstep : int,
         file.write(model_params_lines)
     
 
-def build_model(atchem2_path : str, mechanism_path : str):
+def build_model(atchem2_path : str, mechanism_path : str, model_path : str = ""):
     """Builds the specified AtChem2 model, ready for running"""
     script_dir = os.getcwd()
     os.chdir(atchem2_path)
-    os.system(f"{atchem2_path}/build/build_atchem2.sh {mechanism_path}")
+    os.system(f"{atchem2_path}/build/build_atchem2.sh {mechanism_path} {model_path}/configuration/")
     os.chdir(script_dir)
 
 def run_model(atchem2_path : str, model_path : str = ""):
@@ -182,7 +182,7 @@ def run_model(atchem2_path : str, model_path : str = ""):
     script_dir = os.getcwd()
     os.chdir(atchem2_path)
     if model_path:
-        os.system(f"{atchem2_path}/atchem2 --model={model_path}")
+        os.system(f"{atchem2_path}/atchem2 --model={model_path} --shared_lib={model_path}/configuration/mechanism.so")
     else:
         os.system(f"{atchem2_path}/atchem2")
     os.chdir(script_dir)
@@ -302,7 +302,7 @@ def _write_build_run_injections(injection_df : pd.DataFrame, atchem2_path : str,
                            month, year, lat=lat, lon=lon)
         
         #build and run the model
-        build_model(atchem2_path, new_mech_path)
+        build_model(atchem2_path, new_mech_path, new_model_dir)
         run_model(atchem2_path, new_model_dir)
         
         #read the model output and append it to the stitched df
@@ -450,7 +450,7 @@ BUILDING OF MANY INDIVIDUAL MODELS.""")
                            month, year, lat=lat, lon=lon)
         
         #build and run the model
-        build_model(atchem2_path, new_mech_path)
+        build_model(atchem2_path, new_mech_path, new_model_dir)
         run_model(atchem2_path, new_model_dir)
         
         #read the model output and append it to the stitched df
@@ -604,7 +604,7 @@ def write_build_run(atchem2_path : str, mech_path : str, day : int, month : int,
                            month, year, lat=lat, lon=lon)
         
         #build and run the model
-        build_model(atchem2_path, new_mech_path)
+        build_model(atchem2_path, new_mech_path, new_model_dir)
         run_model(atchem2_path, new_model_dir)
         
         #read the model output 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The following rules apply to inputs to AtChemTools functions:
 Below is a description of a selection of functions defined within `AtChemTools/build_and_run.py` which can be imported into your python script using `from AtChemTools import build_and_run`, provided you have properly exported AtChemTools to PYTHONPATH.
 
 ### AtChemTools.build_and_run.write_config
-Alters the configuration files for a given AtChem2 run directory based on the function arguments. Will also produce the corresponding constraint files (if needed) in the required locations.
-- `atchem2_path` (str): The path to an AtChem2 directory for which the configuration files will be edited. This path should be to the root AtChem2 directory.
+Alters the configuration files for a given AtChem2 model directory based on the function arguments. Will also produce the corresponding constraint files (if needed) in the required locations.
+- `model_path` (str): The path to an AtChem2 model directory for which the configuration files will be edited. This path should be to the model directory, e.g. "AtChem2/model/".
 - `initial_concs` (pd.Series = pd.Series()): A series of initial species concentrations. The index should be a sequence of species names present in the mechanism used, and values should be the corresponding starting concentrations for each species.
 - `spec_constrain` (pd.DataFrame = pd.DataFrame()): A dataframe of species constraints for use in the simulation. The index should be a time series in seconds, the columns should be names of each species that should be constrained, and the values correspond to the desired species concentration at each time. NaN can be used and will be removed for each species constraint prior to editing the configuration files.
 - `spec_constant` (pd.Series = pd.Series()): A series of species that should be held at constant concentration throughout the simulation. The index should be a sequence of species names present in the mechanism used, and values should be the corresponding constant concentrations for each species.
@@ -58,7 +58,7 @@ Alters the configuration files for a given AtChem2 run directory based on the fu
 - `rate_output` (list=[]): A list of species names corresponding to desired rate output species.
 ### AtChemTools.build_and_run.write_model_params
 Edits the `model.parameters` configuration file in the specified location based on the information provided.
-- `atchem2_path` (str): The path to an AtChem2 directory for which the `model.parameters` file will be edited. This path should be to the root AtChem2 directory.
+- `atchem2_path` (str): The path to an AtChem2 model directory for which the `model.parameters` file will be edited. This path should be to the model directory, e.g. "AtChem2/model/".
 - `nsteps` (int): The number of steps that the model should run for.
 - `model_tstep` (int): The length of each timestep in seconds. This model timestep is currently also used for the concentration and rate output timestep, meaning models will output data for every step of the model.
 - `tstart` (int): The start time of the model in seconds. This should be in UTC time in order to properly calculate photolysis rates.
@@ -74,6 +74,7 @@ Runs the AtChem2 bash script to build the model at the specified path.
 ### AtChemTools.build_and_run.run_model
 Runs the specified AtChem2 excecutable. The build script should be run before using this function.
 - `atchem2_path` (str): The path to an AtChem2 directory which will be run. This path should be to the root AtChem2 directory.
+- `model_path` (str = ""): The path to an AtChem2 model directory used as the first argument to the atchem2 executable. If this is left as the default empty string, then no model directory argument will be passed to the executable.
 ### AtChemTools.build_and_run.write_build_run
 Uses many of the above functions to edit the configuration files in a given directory, build the model with a specified mechanism, run the model, and save the output to pandas dataframes which are output by the function. Outputs: pandas DataFrames containing the species concentrations, loss rates, production rates, environmental outputs, photolysis rates output.
 
@@ -96,6 +97,7 @@ Uses many of the above functions to edit the configuration files in a given dire
 - `env_vals` (pd.Series = pd.Series(["298.15", "1013.25", "NOTUSED","3.91e+17", "0.41", "NOTUSED", "NOTUSED", "NOTUSED", "OPEN",  "NOTUSED"],  index = ["TEMP", "PRESS",  "RH", "H2O", "DEC", "BLHEIGHT", "DILUTE", "JFAC", "ROOF", "ASA"])): A series of environmental parameters that should be used in the simulation. The index should be a sequence of environmental parameter names, and values should be the corresponding value for each parameter. If any required environmental parameters are missing from the series, then they will be filled with default values. Will also accept non-default parameter names for custom AtChem2 versions that include additional environmental parameters.
 - `spec_output` (list = []): A list of species names corresponding to desired concentration output species.
 - `rate_output` (list=[]): A list of species names corresponding to desired rate output species.
+- `keep_rundirs` (bool = False): Determines whether to keep temporary model directories created for the purposes of running the simulation. A unique model sub-directory name will be generated (model1, model2, model3, etc...) within the root AtChem2 directory to run the model. If this argument is `False` (default), then this temporary model sub-directory will be deleted once the model has finished running. If this argument is `True`, then the sub-directory will not be deleted.
 - `injection_df` (pd.DataFrame = pd.DataFrame()): A dataframe of species concentrations at specified points throughout the simulation. This was originally created to facilitate simulation of 'injections' of species into atmospheric simulation chambers, however the concetration will be adjusted regardless of the current species concentration. This may result in an instantaneous *decrease* in species concentrations (as opposed to an increase, as would occur with a species injection) if the concentration is above the desired value. This can be thought of as similar to constraining species (e.g. using `spec_constrain`), however the species concentrations are allowed to vary freely between the defined injection concentrations.
     The index should be a time series in seconds, the columns should be names of each species that should be 'injected', and the values correspond to the desired species concentration at each time. NaN can be used and will be removed for each species constraint prior to editing the configuration files.
     This functionality works by running multiple sequential simulations, a new simulation at each 'injection' time, with the initial concentrations of each simulation dictated by the output of the previous simulation (except for the 'injected' species concentration which is adjusted to match the desired concentration). This cannot currently be used alongside `nox_series`.


### PR DESCRIPTION
As mentioned in #1 , we currently copy the entire root AtChem2 directory to a temporary location to run a new model. This is unnecessary as AtChem2 allows for multiple `model` sub-directories that point to the same source code.
These changes mean that the automated build and run functions copy `model` sub-directories instead of the whole source code. There is also an option to keep the copied model directories instead of deleting them once the model is complete.